### PR TITLE
Improve ffmpeg command to transcode flac

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,10 +209,16 @@ In this case you could set;
 BNB_SUBSONIC_CUSTOM_CLIENTS="audio/flac"
 ```
 
-This would result in 2 players in Navidrome, one called 'bonob', the other called 'bonob+audio/flac'.  You could then configure a custom flac transcoder in Navidrome that re-samples the flacs to a sonos supported format, ie [Using something like this](https://stackoverflow.com/questions/41420391/ffmpeg-flac-24-bit-96khz-to-16-bit-48khz) or [this](https://stackoverflow.com/questions/52119489/ffmpeg-limit-audio-sample-rate);
+This would result in 2 players in Navidrome, one called 'bonob', the other called 'bonob+audio/flac'.  You could then configure a custom flac transcoder in Navidrome that re-samples the flacs to a sonos supported format, ie [Using something like this](https://stackoverflow.com/questions/41420391/ffmpeg-flac-24-bit-96khz-to-16-bit-48khz) or [this](https://stackoverflow.com/questions/52119489/ffmpeg-limit-audio-sample-rate):
 
 ```bash
-ffmpeg -i %s -af aformat=sample_fmts=s16:sample_rates=44100|48000 -f flac -
+ffmpeg -i %s -af aformat=sample_fmts=s16|s32:sample_rates=8000|11025|16000|22050|24000|32000|44100|48000 -f flac -
+```
+
+**Note for Sonos S1:** [24-bit depth is only supported by Sonos S2](https://support.sonos.com/s/article/79?language=en_US), so if your system is still on Sonos S1, transcoding should convert all FLACs to 16-bit:
+
+```bash
+ffmpeg -i %s -af aformat=sample_fmts=s16:sample_rates=8000|11025|16000|22050|24000|32000|44100|48000 -f flac -
 ```
 
 ### Changing Icon colors

--- a/README.md
+++ b/README.md
@@ -209,10 +209,10 @@ In this case you could set;
 BNB_SUBSONIC_CUSTOM_CLIENTS="audio/flac"
 ```
 
-This would result in 2 players in Navidrome, one called 'bonob', the other called 'bonob+audio/flac'.  You could then configure a custom flac transcoder in Navidrome that re-samples the flacs to a sonos supported format, ie [Using something like this](https://stackoverflow.com/questions/41420391/ffmpeg-flac-24-bit-96khz-to-16-bit-48khz);
+This would result in 2 players in Navidrome, one called 'bonob', the other called 'bonob+audio/flac'.  You could then configure a custom flac transcoder in Navidrome that re-samples the flacs to a sonos supported format, ie [Using something like this](https://stackoverflow.com/questions/41420391/ffmpeg-flac-24-bit-96khz-to-16-bit-48khz) or [this](https://stackoverflow.com/questions/52119489/ffmpeg-limit-audio-sample-rate);
 
 ```bash
-ffmpeg -i %s -af aresample=resampler=soxr:out_sample_fmt=s16:out_sample_rate=48000 -f flac -
+ffmpeg -i %s -af aformat=sample_fmts=s16:sample_rates=44100|48000 -f flac -
 ```
 
 ### Changing Icon colors


### PR DESCRIPTION
The command previously suggested forced the output sample rate to 48 kHz, even if the input was lower, at 44.1 kHz. 
This new command lets `ffmpeg` select the appropriate output sample rate to minimize conversion. 
Documentation: https://www.ffmpeg.org/ffmpeg-filters.html#aformat-1