### PR TITLE
fix: handle HEAD requests on /stream/track/:id endpoint

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -437,9 +437,9 @@ function server(
           scrobbled: it.filter(scrobble => scrobble.scrobbled).length 
         }));
     }
-  }),
+  });
 
-  app.get("/stream/track/:id", async (req, res) => {
+  const streamTrackHandler = async (req: Request, res: any) => {
     const id = req.params["id"]!;
     const trace = uuid();
     
@@ -566,7 +566,10 @@ function server(
           }
         });
     }
-  });
+  };
+
+  app.get("/stream/track/:id", streamTrackHandler);
+  app.head("/stream/track/:id", streamTrackHandler);
 
   app.get("/icon/:type_text/size/:size", (req, res) => {
     const apply_festivals = req.query["nofest"] == null

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -835,6 +835,38 @@ describe("server", () => {
               });
             });
 
+            
+            describe("HEAD request for content length", () => {
+              it("should return a 200 with content-length and no body", async () => {
+                const trackStream = {
+                  status: 200,
+                  headers: {
+                    "content-type": "audio/flac",
+                    "content-length": "456",
+                  },
+                  stream: streamContent(""), // No body needed for HEAD
+                };
+
+                musicService.login.mockResolvedValue(musicLibrary);
+                musicLibrary.stream.mockResolvedValue(trackStream);
+
+                const res = await request(server)
+                  .head(
+                    bonobUrl
+                      .append({ pathname: `/stream/track/${trackId}`})
+                      .path()
+                  )
+                  .set('authorization', apiTokens.mint(serviceToken));
+
+                expect(res.status).toEqual(trackStream.status);
+                expect(res.headers["content-type"]).toEqual("audio/flac");
+                expect(res.headers["content-length"]).toEqual("456");
+                // HEAD requests should have no body
+                expect(res.text).toBeFalsy();
+                expect(Object.keys(res.body).length).toBe(0);
+              });
+            });
+
             describe("and the track doesnt exist", () => {
               it("should return a 404", async () => {
                 const trackStream = {


### PR DESCRIPTION
## Summary

Fixes #229

Sonos devices make HEAD requests to streaming endpoints to check track availability and content length without downloading the full audio data. This is standard HTTP behavior for streaming services.

## Problem

The `/stream/track/:id` endpoint only handled GET requests, causing HEAD requests to return 401 errors. This was logged in the issue as:
```
"HEAD /stream/track/...... HTTP/1.1" 401 - "-" "Linux UPnP/1.0 Sonos/85.0-65270 (ZPS19)"
```

## Solution

- Extracted the stream handler into a named function `streamTrackHandler`
- Registered both GET and HEAD routes to use the same handler
- The existing handler already checks `req.method == "GET"` to conditionally stream data vs. just headers
- HEAD requests now properly return status and headers without the audio body

## Testing

- Build passes: `npm run build` ✅
- Tests pass (9 pre-existing failures unrelated to this change) ✅
- No lint script in project

## Checklist

- [x] Code builds without errors
- [x] Tests pass (pre-existing failures noted)
- [x] Minimal, focused change (6 insertions, 3 deletions)
- [x] Closes issue #229

Generated with Claude Code