### PR TITLE
Fix flaky date tests caused by UTC vs local timezone mismatch

### DIFF
--- a/tests/clock.test.ts
+++ b/tests/clock.test.ts
@@ -29,14 +29,14 @@ function describeFixedDateMonthEvent(
   const month = dateMonth.split("/")[1];
 
   describe(name, () => {
-    it(`should return true for ${randomYear}-${month}-${date}T00:00:00 ragardless of year`, () => {
-      expect(f({ now: () => dayjs(`${randomYear}-${month}-${date}T00:00:00Z`) })).toEqual(true);
+    it(`should return true for ${randomYear}-${month}-${date}T00:00:00 regardless of year`, () => {
+      expect(f({ now: () => dayjs(`${randomYear}-${month}-${date}T00:00:00`) })).toEqual(true);
     });
-  
+
     it(`should return true for ${randomYear}-${month}-${date}T12:00:00 regardless of year`, () => {
-      expect(f({ now: () => dayjs(`${randomYear}-${month}-${date}T12:00:00Z`) })).toEqual(true);
+      expect(f({ now: () => dayjs(`${randomYear}-${month}-${date}T12:00:00`) })).toEqual(true);
     });
-  
+
     it(`should return true for ${randomYear}-${month}-${date}T23:59:00 regardless of year`, () => {
       expect(f({ now: () => dayjs(`${randomYear}-${month}-${date}T23:59:00`) })).toEqual(true);
     });


### PR DESCRIPTION
The implementation in src/clock.ts uses .date()/.month() which return local time. The tests passed UTC times (Z suffix), so in any timezone west of UTC the local date became the previous day - e.g. midnight UTC on 25/12 is 24/12 in PDT, breaking isChristmas.

Drop the Z suffix so the test times are interpreted as local time, matching the implementation. Also fix a typo in one test description (ragardless -> regardless).