### PR TITLE
Modernize CI and speed up Docker build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,11 +17,11 @@ jobs:
     steps:
       -
         name: Check out the repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
       -
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v5
         with:
-          node-version: 20
+          node-version: 22
       -
         run: npm install
       -
@@ -35,19 +35,19 @@ jobs:
     steps:
       -
         name: Check out the repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
       -
         name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
       -
         name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
       -
         name: Docker meta
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
           images: |
             simojenki/bonob
@@ -55,24 +55,26 @@ jobs:
       -
         name: Login to DockerHub
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       -
         name: Log in to GitHub Container registry
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       -
         name: Push image
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v6
         with:
           context: .
           platforms: linux/amd64,linux/arm/v7,linux/arm64
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -39,11 +39,11 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v5
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -54,7 +54,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
+      uses: github/codeql-action/autobuild@v3
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -68,4 +68,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v3

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,20 +2,6 @@ FROM node:22-bookworm-slim AS build
 
 WORKDIR /bonob
 
-COPY .git ./.git
-COPY src ./src
-COPY docs ./docs
-COPY typings ./typings
-COPY web ./web
-COPY tests ./tests
-COPY jest.config.js .
-COPY register.js .
-COPY .npmrc .
-COPY tsconfig.json .
-COPY package.json .
-COPY package-lock.json .
-
-ENV JEST_TIMEOUT=60000
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && \
@@ -27,13 +13,21 @@ RUN apt-get update && \
         git \
         g++ && \
     apt-get clean && \
-    rm -rf /var/lib/apt/lists/* && \
-    npm install && \
-    npm test && \
-    npm run gitinfo && \
+    rm -rf /var/lib/apt/lists/*
+
+# Install dependencies first so this layer caches when only source changes
+COPY package.json package-lock.json .npmrc ./
+RUN npm ci
+
+# Now copy source and build
+COPY tsconfig.json jest.config.js register.js ./
+COPY src ./src
+COPY typings ./typings
+COPY .git ./.git
+
+RUN npm run gitinfo && \
     npm run build && \
-    rm -Rf node_modules && \
-    NODE_ENV=production npm install --omit=dev
+    npm prune --omit=dev
 
 
 FROM node:22-bookworm-slim
@@ -51,15 +45,6 @@ EXPOSE $BNB_PORT
 
 WORKDIR /bonob
 
-COPY package.json .
-COPY package-lock.json .
-
-COPY --from=build /bonob/build/src ./src
-COPY --from=build /bonob/node_modules ./node_modules
-COPY --from=build /bonob/.gitinfo ./
-COPY web ./web
-COPY src/Sonoswsdl-1.19.6-20231024.wsdl ./src/Sonoswsdl-1.19.6-20231024.wsdl
-
 RUN apt-get update && \
     apt-get -y upgrade && \
     apt-get -y install --no-install-recommends \
@@ -69,9 +54,16 @@ RUN apt-get update && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-USER nobody 
+COPY package.json package-lock.json ./
+COPY --from=build /bonob/build/src ./src
+COPY --from=build /bonob/node_modules ./node_modules
+COPY --from=build /bonob/.gitinfo ./
+COPY web ./web
+COPY src/Sonoswsdl-1.19.6-20231024.wsdl ./src/Sonoswsdl-1.19.6-20231024.wsdl
+
+USER nobody
 WORKDIR /bonob/src
 
-HEALTHCHECK CMD wget -O- http://localhost:${BNB_PORT}/about || exit 1   
+HEALTHCHECK CMD wget -O- http://localhost:${BNB_PORT}/about || exit 1
 
 CMD ["node", "app.js"]


### PR DESCRIPTION
CI workflow:
- Bump GitHub Actions to current major versions (checkout v5, setup-node v5, docker/* v3-v6, codeql v3) so workflows run on Node 24 instead of the deprecated Node 20
- Bump Node version in build_and_test from 20 to 22 (matches the Dockerfile base image)

Dockerfile:
- Drop redundant 'npm test' from the build (already runs in the build_and_test job before the Docker push, repeating it on emulated arm/v7 and arm64 wastes substantial CI minutes)
- Reorder so package.json is copied and 'npm ci' runs before the source is copied, letting Docker cache the install layer when only application code changes
- Use 'npm prune --omit=dev' to strip devDeps in place rather than doing a second full 'npm install'
- Add GHA-backed Docker layer cache (cache-from/cache-to) so subsequent builds reuse layers across runs