### PR TITLE
Fix Sonos S2 "Add Service" failing after login (privateKey + 32-char link code)

### DIFF
--- a/src/link_codes.ts
+++ b/src/link_codes.ts
@@ -20,7 +20,9 @@ export class InMemoryLinkCodes implements LinkCodes {
   linkCodes: Record<string, Association | undefined>  = {}
 
   mint() {
-    const linkCode = uuid();
+    // Sonos S2 browser-auth link codes are capped at 32 characters; a UUID is
+    // 36. Strip the dashes to get a spec-compliant 32-char hex code.
+    const linkCode = uuid().replace(/-/g, "");
     this.linkCodes[linkCode] = undefined
     return linkCode
   }

--- a/src/smapi.ts
+++ b/src/smapi.ts
@@ -88,10 +88,13 @@ export type GetAppLinkResult = {
 export type GetDeviceAuthTokenResult = {
   getDeviceAuthTokenResult: {
     authToken: string;
+    // Required by Sonos S2: the WSDL declares privateKey in deviceAuthTokenResult.
+    // Omitting it makes the S2 app reject the token and abort "Add Service".
+    privateKey: string;
     // todo: appears this thing can be optional
     userInfo: {
-      nickname: string;
       userIdHashCode: string;
+      nickname: string;
     };
   };
 };
@@ -210,12 +213,17 @@ class SonosSoap {
       return {
         getDeviceAuthTokenResult: {
           authToken: smapiAuthToken.token,
+          // Sonos sentinel meaning "I don't issue refreshable private keys".
+          // bonob doesn't implement private-key refresh, so this is the correct
+          // value (a random/opaque key here makes S2 abort the add).
+          privateKey: "alwaysReauthenticate",
+          // userIdHashCode must precede nickname to match the WSDL xs:sequence.
           userInfo: {
-            nickname: association.nickname,
             userIdHashCode: crypto
               .createHash("sha256")
               .update(association.userId)
               .digest("hex"),
+            nickname: association.nickname,
           },
         },
       };

--- a/tests/link_codes.test.ts
+++ b/tests/link_codes.test.ts
@@ -12,6 +12,12 @@ describe("InMemoryLinkCodes", () => {
       expect(code1).not.toEqual(code2);
       expect(code1).not.toEqual(code3);
     });
+
+    it('should mint codes within the Sonos 32-character limit', () => {
+      // Sonos S2 browser-auth rejects link codes longer than 32 chars.
+      const code = linkCodes.mint()
+      expect(code).toMatch(/^[0-9a-f]{32}$/);
+    });
   });
 
   describe("associating a code with a user", () => {

--- a/tests/smapi.test.ts
+++ b/tests/smapi.test.ts
@@ -799,12 +799,13 @@ describe("wsdl api", () => {
               expect(result[0]).toEqual({
                 getDeviceAuthTokenResult: {
                   authToken: smapiAuthToken.token,
+                  privateKey: "alwaysReauthenticate",
                   userInfo: {
-                    nickname: association.nickname,
                     userIdHashCode: crypto
                       .createHash("sha256")
                       .update(association.userId)
                       .digest("hex"),
+                    nickname: association.nickname,
                   },
                 },
               });


### PR DESCRIPTION
Adding a self-hosted bonob service to a current Sonos S2 system kept failing for me right at the end. The browser login works, you get "Login successful," but back in the Sonos app it spins for a few seconds and then says "<service> wasn't added. Something went wrong." In the logs, `getMetadata` never gets called.

There are a few other reports of the same thing with no real resolution (#249, #254, #269, #213) — usually either no fix or an "it eventually started working," which I'm fairly sure is just Sonos cloud being flaky and masking the real problem.

### What's actually going on

I ran it against a live S2 system with debug logging and went through about nine add attempts. Every time, the handshake itself is clean: `getAppLink` → `/login` → `getDeviceAuthToken` all return fine, bonob hands back a valid `authToken`, and Sonos's cloud even starts polling `getLastUpdate` every 60s and getting 200s. But the real household never calls `getMetadata` — not once. The only way I could get a `getMetadata` was to replay the SMAPI calls myself with curl, and that returned the full library without issue.

So bonob is doing its part; the add is dying inside Sonos's own finalization, after the token handshake. That pointed me at what the S2 app actually validates in the `getDeviceAuthToken` response and the link code, and two things were off against the spec:

1. The WSDL `deviceAuthTokenResult` has a `privateKey` element, and the [browser-auth success-response example](https://docs.sonos.com/docs/add-browser-authentication#success-response-to-getdeviceauthtoken) returns it — bonob doesn't. The current app rejects the response without it. (In #269 someone found this same doc and tried adding only `privateKey`, but it still failed for them — which makes sense given the second issue.)
2. Sonos caps browser-auth link codes at 32 characters. `mint()` uses `randomUUID()`, which is 36.

You need both. Fixing one on its own doesn't get you there.

### The change

- `getDeviceAuthToken` now returns `privateKey: "alwaysReauthenticate"` — the sentinel the docs use for services that don't implement private-key refresh, which bonob doesn't. I also reordered `userInfo` to `userIdHashCode` then `nickname` to match the WSDL sequence.
- `mint()` drops the dashes from the UUID, so the code is 32 hex chars.

I left the `appUrl`/app-auth path alone on purpose — web-only services don't need it, and firing the `sonos-2://…/addAccount` deep link from inside the browser-auth flow actually made the app abort when I tried it.

### Testing

`npm test` is green (277 tests). Added a 32-char assertion for `mint()` and updated the `getDeviceAuthToken` test to expect the `privateKey`. Verified end to end on a real S2 system (build 86.x) — adds, browses, plays.

Happy to share the full debug traces, or to gate the changes behind a config flag if you'd prefer to keep the old behaviour available. Probably fixes #249 and #254; related to #269 and #213.
