### PR TITLE
docs: sonos-s2-setup - Content Actions must be configured for rating icons to appear

### DIFF
--- a/docs/sonos-s2-setup.md
+++ b/docs/sonos-s2-setup.md
@@ -123,7 +123,21 @@ json in the Service Configuration should look like this.
     Artists - artists
     Tracks - tracks
 * Content Actions
-  * No changes
+  * Without this step, no rating/heart icon will ever appear anywhere in the
+    Sonos app, for any track. bonob's own rateItem/dynamic rating
+    implementation alone is not sufficient in the current Sonos app; Sonos
+    reads rating icons from this page specifically. This gives you a simple
+    love/heart toggle only, bonob's older 5 star scale doesn't map onto
+    this model (max two icons, two states each).
+  * Add one Content Action:
+    * Resources: `Track`, Placement: `NOW_PLAYING`
+    * State `100` (unrated): Icon `HEART_UNSELECTED`, On Action Set Value `101`
+    * State `101` (loved): Icon `HEART_SELECTED`, On Action Set Value `100`
+    * Each state's "On Action Set Value" must be the other state's number,
+      not its own, or the button becomes a no-op.
+  * Save, then separately go to Service Configuration and click
+    Refresh, then Send to actually deploy the change (about 10 minutes to
+    propagate), then restart the Sonos app.
 * Service Deployment Settings
   * Sonos ID: Your Sonos ID (Sonos S2 app -> System Settings -> Manage -> About your system -> "Sonos ID"). This is how only your controller sees the new service.
   * System Name: Whatever you want


### PR DESCRIPTION
Closes #315

The setup guide currently says to leave Content Actions as "No changes" (line 125-126). This means the rating/heart icon never appears anywhere in the Sonos app, for any track, regardless of bonob's rateItem implementation.

Per Sonos's current docs (docs.sonos.com/docs/configure-ratings, develop-ratings), rating icons on the Now Playing screen are driven entirely by a manually configured Content Actions entry on the Integration Submission Form, separate from the dynamic/PresentationMap mechanism bonob implements itself. That implementation is correct and necessary but not sufficient on its own in the current app.

This PR replaces "No changes" with the working config for a simple love/heart toggle, matching bonob's own ratingAsInt encoding in src/smapi.ts (unrated = 100, loved = 101):

- Content Action: resources Track, placement NOW_PLAYING
- State 100 (unrated): icon HEART_UNSELECTED, On Action Set Value 101
- State 101 (loved): icon HEART_SELECTED, On Action Set Value 100
- Each state's On Action Set Value must point at the other state, not itself, or the button becomes an inert no-op
- Also notes the separate Service Configuration Refresh then Send step needed to actually deploy the change, plus the app restart needed to pick it up

Confirmed working end to end on v0.12.0 against a Navidrome backend, Sonos S2, Android app.