### PR TITLE
fix: mark internetRadio root as container

### DIFF
--- a/src/smapi.ts
+++ b/src/smapi.ts
@@ -938,7 +938,7 @@ function bindSmapiSoapServiceToExpress(
                         },
                         {
                           id: "internetRadio",
-                          itemType: "stream",
+                          itemType: "container",
                           title: lang("internetRadio"),
                           albumArtURI: albumArtURI(iconArtURI(bonobUrl, "radio").href()),
                         },


### PR DESCRIPTION
The internetRadio root item is browsable, not playable. Mark it as a container so Sonos requests its child stations correctly.